### PR TITLE
Stgrid can be a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test
 
 # virtualenv
 venv
+.vscode/settings.json


### PR DESCRIPTION
`stgrid` can now be a list of stgrids. I implemented this, as I cannot pass very large stgrids such as RADKLIM to the Processor without running out of memory. Now I can pass e.g. yearly xarray Datasets to the processor and process them one after the other, resulting in longer computation time, fragmented outputs (one clipped and aggregated file for each area and each stgrid, results have to be merged by the user) but also less / configurable memory usage.